### PR TITLE
arm image

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -23,6 +23,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: "linux/arm64,linux/amd64"
           push: true
           tags: |
             timwitzdam/gitsave:${{ steps.get-latest-tag.outputs.tag }}


### PR DESCRIPTION
This builds an image for two different platform, referenced by the same name. The machine will automatically pull the version it needs.

This supports apple silicon and x64.